### PR TITLE
fix: add support for tram release candidates

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Push Nightly
         uses: docker/build-push-action@v2
-        if: "${{steps.pick_engine.outputs.engine == "unicycle" }}"
+        if: ${{steps.pick_engine.outputs.engine == "unicycle" }}
         with:
           push: ${{ github.event_name == 'scheduled'  || github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Push Release
         uses: docker/build-push-action@v2
-        if: "${{steps.pick_engine.outputs.engine != "unicycle" }}"
+        if: ${{steps.pick_engine.outputs.engine != "unicycle" }}
         with:
           push: startsWith(github.ref, 'refs/tags/')
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Push Nightly
         uses: docker/build-push-action@v2
-        if: ${{steps.pick_engine.outputs.engine == "unicycle" }}
+        if: ${{steps.pick_engine.outputs.engine == 'unicycle' }}
         with:
           push: ${{ github.event_name == 'scheduled'  || github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Push Release
         uses: docker/build-push-action@v2
-        if: ${{steps.pick_engine.outputs.engine != "unicycle" }}
+        if: ${{steps.pick_engine.outputs.engine != 'unicycle' }}
         with:
           push: startsWith(github.ref, 'refs/tags/')
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -95,12 +95,24 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Release
+      - name: Push Nightly
         uses: docker/build-push-action@v2
+        if: "${{steps.pick_engine.outputs.engine == "unicycle" }}"
         with:
-          push: ${{ github.event_name == 'scheduled' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'scheduled'  || github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          target: base_package
+          target: unicycle_package
+          build-args: |
+            engine=${{steps.pick_engine.outputs.engine}}
+
+      - name: Push Release
+        uses: docker/build-push-action@v2
+        if: "${{steps.pick_engine.outputs.engine != "unicycle" }}"
+        with:
+          push: startsWith(github.ref, 'refs/tags/')
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: release_package
           build-args: |
             engine=${{steps.pick_engine.outputs.engine}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,32 @@ USER root
 RUN apt-get update && apt-get install -y \
         jq dos2unix
 
-RUN pip3 install hamlet-cli
+RUN pip3 install hamlet
 
 WORKDIR /build/
 
 ENV HAMLET_HOME_DIR='/build/'
-RUN hamlet engine install-engine "${engine}"
 
+RUN [ "${engine}" != "unicyle" ] && hamlet engine install-engine "unicycle"
+RUN [ "${engine}" != "tram" ] && hamlet engine install-engine "tram"
+RUN hamlet engine set-engine "${engine}"
 
 # Copy the latest into the container
-FROM scratch as base_package
+FROM scratch as unicycle_package
 
 COPY --from=builder /build/engine/engines/unicycle/engine-core          /engine-core
 COPY --from=builder /build/engine/engines/unicycle/engine               /engine
 COPY --from=builder /build/engine/engines/unicycle/engine-plugin-aws    /engine-plugin-aws
 COPY --from=builder /build/engine/engines/unicycle/engine-plugin-azure  /engine-plugin-azure
 COPY --from=builder /build/engine/engines/unicycle/executor-bash        /executor-bash
+
+# Copy the provided tram package into the repository
+FROM scratch as release_package
+
+ARG engine="tram"
+
+COPY --from=builder /build/engine/engines/${engine}/hamlet-engine-base/engine-core          /engine-core
+COPY --from=builder /build/engine/engines/${engine}/hamlet-engine-base/engine               /engine
+COPY --from=builder /build/engine/engines/${engine}/hamlet-engine-base/engine-plugin-aws    /engine-plugin-aws
+COPY --from=builder /build/engine/engines/${engine}/hamlet-engine-base/engine-plugin-azure  /engine-plugin-azure
+COPY --from=builder /build/engine/engines/${engine}/hamlet-engine-base/executor-bash        /executor-bash


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Adds the folder structure for building release images based on existing tram releases. Tihs allows for the selection of a specific tram release to use for the new tagged release

## Motivation and Context

The process intended for tagged releases of this repo is to select a tram release candidate and include that as part of the state file listed in the repo. However this was failing as the engine folder layout is different between unicycle and tram releases of the engine

## How Has This Been Tested?

tested locally

## Related Changes


### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

