### PR TITLE
feat: add a nightly deployment to track status

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,6 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - uses: chrnorm/deployment-action@releases/v1
+        name: Nightly deployment details
+        id: nightly_deployment
+        if: github.event_name == 'scheduled'
+        with:
+          initial_status: "in_progress"
+          token: "${{ github.token }}"
+          environment: nightly
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -96,7 +105,7 @@ jobs:
 
       - name: Push Nightly
         uses: docker/build-push-action@v2
-        if: ${{steps.pick_engine.outputs.engine == 'unicycle' }}
+        if: steps.pick_engine.outputs.engine == 'unicycle'
         with:
           push: ${{ github.event_name == 'scheduled'  || github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -107,7 +116,7 @@ jobs:
 
       - name: Push Release
         uses: docker/build-push-action@v2
-        if: ${{steps.pick_engine.outputs.engine != 'unicycle' }}
+        if: steps.pick_engine.outputs.engine != 'unicycle'
         with:
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
@@ -115,3 +124,19 @@ jobs:
           target: release_package
           build-args: |
             engine=${{steps.pick_engine.outputs.engine}}
+
+      - name: Nightly deployment status (success)
+        if: github.event_name == 'scheduled' && success()
+        uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ github.token }}"
+          state: "success"
+          deployment_id: ${{ steps.nightly_deployment.outputs.deployment_id }}
+
+      - name: Nightly deployment status (failure)
+        if: github.event_name == 'scheduled' && failure()
+        uses: chrnorm/deployment-status@releases/v1
+        with:
+          token: "${{ github.token }}"
+          state: "failure"
+          deployment_id: ${{ steps.nightly_deployment.outputs.deployment_id }}


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->

- New feature (non-breaking change which adds functionality)

## Description
<!--- Describe your changes in detail -->
- Adds a nightly deployment status update so that it can be tracked and monitored in slack

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Allows for tracking the status of the nightly builds to ensure they aren't forgotten about

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Will be tested in pipeline

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

